### PR TITLE
Add simple AI web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # MYUI4AI
-This is my user interface that I'm designing for my a I
+
+A simple web interface for interacting with an AI model using the OpenAI API.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set your OpenAI API key in the environment:
+   ```bash
+   export OPENAI_API_KEY=your_key_here
+   ```
+3. Run the application:
+   ```bash
+   python -m app.app
+   ```
+
+The interface will be available at `http://localhost:5000`.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,3 @@
+from .app import app
+
+__all__ = ['app']

--- a/app/app.py
+++ b/app/app.py
@@ -1,0 +1,29 @@
+from flask import Flask, render_template, request, jsonify
+import os
+import openai
+
+app = Flask(__name__)
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/chat', methods=['POST'])
+def chat():
+    data = request.get_json()
+    prompt = data.get('prompt', '')
+    if not prompt:
+        return jsonify({'error': 'Prompt is required'}), 400
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}]
+        )
+        ai_message = response.choices[0].message['content'].strip()
+        return jsonify({'response': ai_message})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Tool Interface</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        #response { white-space: pre-wrap; border: 1px solid #ccc; padding: 1em; margin-top: 1em; }
+    </style>
+</head>
+<body>
+    <h1>AI Tool Interface</h1>
+    <textarea id="prompt" rows="4" cols="50" placeholder="Enter your prompt here..."></textarea><br>
+    <button onclick="sendPrompt()">Send</button>
+    <div id="response"></div>
+    <script>
+        async function sendPrompt() {
+            const prompt = document.getElementById('prompt').value;
+            const res = await fetch('/chat', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({prompt})
+            });
+            const data = await res.json();
+            if (data.response) {
+                document.getElementById('response').textContent = data.response;
+            } else {
+                document.getElementById('response').textContent = 'Error: ' + data.error;
+            }
+        }
+    </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+openai


### PR DESCRIPTION
## Summary
- implement a Flask app that calls the OpenAI API
- create a basic HTML page to interact with the AI
- document setup and usage in README
- specify Flask and openai dependencies

## Testing
- `python -m app.app --help` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6847badec05c832ab259a4a526559a92